### PR TITLE
Feature/erlang 21.1 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: erlang
 otp_release:
   - 19.3
   - 20.2
+  - 21.1
 
 script:
   - rebar3 do dialyzer, eunit, proper -n 1000

--- a/src/ecrn_time.erl
+++ b/src/ecrn_time.erl
@@ -178,15 +178,8 @@ until_next_daytime_or_days_from_now(Date, Period, Days) ->
     end.
 
 normalize_seconds(Date, Seconds) ->
-    case Seconds - current_time(Date) of
-        Value when Value >= 0 ->
-            Value;
-        _ ->
-            erlang:display(erlang:get_stacktrace()),
-            throw(invalid_once_exception)
-    end.
+    Seconds - current_time(Date).
 
 -spec current_time(calendar:datetime()) -> erlcron:seconds().
 current_time({_, {H,M,S}}) ->
     S + M * 60 + H * 3600.
-


### PR DESCRIPTION
The main issue is the use of `get_stack_trace/0`, however things sort of cascade from there on - since the spec claims an integer is always returned, the `catch` clause isn't picked up by dialyzer, and it snowballs on.

Since we haven't actually seen this happen in production (to my knowledge), and tests never trigger that branch, I think it's okay to assume it just doesn't happen.

Alternatively, we could just have that function return a result and handle it wherever that function is used.